### PR TITLE
pblio: Fix block addressing

### DIFF
--- a/apps/pblio/spc/spc.go
+++ b/apps/pblio/spc/spc.go
@@ -74,27 +74,25 @@ func (s *SpcInfo) sendio(wg *sync.WaitGroup,
 			if io.Isread {
 				if s.pblcache == nil {
 					s.asus[io.Asu-1].ReadAt(buffer[0:io.Blocks*4*KB],
-						int64(io.Offset)*int64(4*KB))
+						int64(io.Offset)*4*KB)
 				} else {
 					read(s.asus[io.Asu-1],
 						s.pblcache,
-						uint16(io.Asu),
-						uint64(io.Offset)*uint64(4*KB),
-						uint64(s.blocksize*KB),
-						int(io.Blocks),
+						io.Asu,
+						io.Offset,
+						io.Blocks,
 						buffer[0:io.Blocks*4*KB])
 				}
 			} else {
 				if s.pblcache == nil {
 					s.asus[io.Asu-1].WriteAt(buffer[0:io.Blocks*4*KB],
-						int64(io.Offset)*int64(4*KB))
+						int64(io.Offset)*4*KB)
 				} else {
 					write(s.asus[io.Asu-1],
 						s.pblcache,
-						uint16(io.Asu),
-						uint64(io.Offset)*uint64(4*KB),
-						uint64(s.blocksize*KB),
-						int(io.Blocks),
+						io.Asu,
+						io.Offset,
+						io.Blocks,
 						buffer[0:io.Blocks*4*KB])
 				}
 			}

--- a/cache/addressutils.go
+++ b/cache/addressutils.go
@@ -15,29 +15,24 @@
 //
 package cache
 
-import (
-	"github.com/lpabon/godbc"
-)
-
 const (
-	MAX_LBA = uint64(1 << 48)
+	MAX_BLOCKS = uint64(1 << 32)
 )
 
 type Address struct {
-	Devid uint16
-	Lba   uint64
+	Devid uint32
+	Block uint32
 }
 
 func Address64(address Address) uint64 {
-	godbc.Require(address.Lba < MAX_LBA)
-	return (uint64(address.Devid) << 48) | uint64(address.Lba)
+	return (uint64(address.Devid) << 32) | uint64(address.Block)
 }
 
 func AddressValue(address uint64) Address {
 	var a Address
 
-	a.Devid = uint16(address >> 48)
-	a.Lba = uint64(0xFFFFFFFFFFFF) & address
+	a.Devid = uint32(address >> 32)
+	a.Block = uint32(address)
 
 	return a
 }

--- a/cache/addressutils_test.go
+++ b/cache/addressutils_test.go
@@ -22,13 +22,13 @@ import (
 
 func TestAddressUtils(t *testing.T) {
 	a := Address{
-		Devid: uint16(9876),
-		Lba:   uint64(123456789),
+		Devid: 9876,
+		Block: 123456789,
 	}
 
 	merged := Address64(a)
 	converted := AddressValue(merged)
 
 	tests.Assert(t, a.Devid == converted.Devid)
-	tests.Assert(t, a.Lba == converted.Lba)
+	tests.Assert(t, a.Block == converted.Block)
 }

--- a/cache/cachemap_test.go
+++ b/cache/cachemap_test.go
@@ -154,7 +154,7 @@ func TestCacheMapSimple(t *testing.T) {
 	tests.Assert(t, err == nil)
 	tests.Assert(t, hitmap.Hits == 1)
 	tests.Assert(t, hitmap.Hitmap[0] == true)
-	tests.Assert(t, hitmap.Hits == int(io.Blocks))
+	tests.Assert(t, hitmap.Hits == io.Blocks)
 
 	logmsg = <-mocklog
 	logio = logmsg.IoPkt()

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -21,6 +21,7 @@ import (
 )
 
 func SubBlockBuffer(buffer []byte, blocksize, block, nblocks uint32) []byte {
-	godbc.Require(int((block+nblocks)*blocksize) <= len(buffer))
+	godbc.Require(int((block+nblocks)*blocksize) <= len(buffer),
+		blocksize, block, nblocks, len(buffer))
 	return buffer[block*blocksize : (block+nblocks)*blocksize]
 }


### PR DESCRIPTION
Pblio was still using byte offset to access the cache.  Needed
to also adjust the address utilities accordingly.  Cacheio
needed to be updated to use blocks instead of byte
offset.  Also solved the following issues:

Fixes issue #41.
Fixes issue #42.