### PR TITLE
Fixes for pblio and version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 install:
+- bash .travis-fork-fix
 - go get github.com/mattn/goveralls
 - go get github.com/lpabon/tm
 - go get -v -d ./...
@@ -8,18 +9,10 @@ env:
   - secure: XbgkCwQcPJzpkaVR9HJPyKezpEDrZQEHwhYueiWgsC7YKJIqROfHQ/EPZNQpXCW/v24Sp4RQeQf4RMcnnj5Dy7XBzbkBmMIjZs/Tvp8wTwFk0BqrD2oFm7Uc//iAIIgrUnOgJl/d+GcmZHyVOhHiAuNwJTIP4Cnmjk8DKL7DdU8=
 matrix:
   include:
-  - go: 1.2.2
-    env: OPTIONS="" GOVER="1.2"
-  - go: 1.3.3
-    env: OPTIONS="-race" GOVER="1.3"
-  - go: 1.4.2
-    env: COVERAGE="true" GOVER="1.4"
-before_script:
-- if [[ "$GOVER" = "1.4" ]] ; then go get golang.org/x/tools/cmd/vet; fi
-- if [[ "$GOVER" = "1.4" ]] ; then go get golang.org/x/tools/cmd/cover; fi
-- if [[ "$GOVER" != "1.4" ]] ; then go get code.google.com/p/go.tools/cmd/cover; fi
-- if [[ "$GOVER" != "1.4" ]] ; then go get code.google.com/p/go.tools/cmd/vet; fi
-- bash .travis-fork-fix
+  - go: 1.5.3
+    env: OPTIONS="-race"
+  - go: 1.6.1
+    env: COVERAGE="true" OPTIONS=""
 script:
 - go fmt ./... | wc -l | grep 0
 - go vet ./...

--- a/apps/pblio/pblioplot.py
+++ b/apps/pblio/pblioplot.py
@@ -56,8 +56,14 @@ data_sources = ['DS:tlat_d:COUNTER:600:0:U',
                 'DS:total:COUNTER:600:0:U',
                 'DS:asu1_rl_d:COUNTER:600:0:U',
                 'DS:asu1_rl_c:COUNTER:600:0:U',
+                'DS:asu1_wl_d:COUNTER:600:0:U',
+                'DS:asu1_wl_c:COUNTER:600:0:U',
                 'DS:asu2_rl_d:COUNTER:600:0:U',
                 'DS:asu2_rl_c:COUNTER:600:0:U',
+                'DS:asu2_wl_d:COUNTER:600:0:U',
+                'DS:asu2_wl_c:COUNTER:600:0:U',
+                'DS:asu3_wl_d:COUNTER:600:0:U',
+                'DS:asu3_wl_c:COUNTER:600:0:U',
                 ]
 
 # Create db
@@ -96,6 +102,15 @@ for line in fp.readlines():
     asu2_rl_d = int(stat['spc']['asu'][1]['read']['latency']['duration']/1000)
     asu2_rl_c = stat['spc']['asu'][1]['read']['latency']['count']
 
+    asu1_wl_d = int(stat['spc']['asu'][0]['write']['latency']['duration']/1000)
+    asu1_wl_c = stat['spc']['asu'][0]['write']['latency']['count']
+
+    asu2_wl_d = int(stat['spc']['asu'][1]['write']['latency']['duration']/1000)
+    asu2_wl_c = stat['spc']['asu'][1]['write']['latency']['count']
+
+    asu3_wl_d = int(stat['spc']['asu'][2]['write']['latency']['duration']/1000)
+    asu3_wl_c = stat['spc']['asu'][2]['write']['latency']['count']
+
     # Get cache
     try:
         cache_hits = stat['cache']['readhits']
@@ -131,8 +146,14 @@ for line in fp.readlines():
         ("%d:" % total)+
         ("%d:" % asu1_rl_d)+
         ("%d:" % asu1_rl_c)+
+        ("%d:" % asu1_wl_d)+
+        ("%d:" % asu1_wl_c)+
         ("%d:" % asu2_rl_d)+
-        ("%d" % asu2_rl_c))
+        ("%d:" % asu2_rl_c)+
+        ("%d:" % asu2_wl_d)+
+        ("%d:" % asu2_wl_c)+
+        ("%d:" % asu3_wl_d)+
+        ("%d" % asu3_wl_c))
 
     # Save the end time for graphs
     end_time = stat['time']
@@ -161,21 +182,66 @@ rrdtool.graph('tlat.png',
     'LINE2:writelatms#0000FF:Write Total Latency')
 
 # Graph ASU1 and ASU2 Read Latency
-rrdtool.graph('asu_read_latency.png',
+rrdtool.graph('asu1_read_latency.png',
+    '--start', '%d' % start_time,
+    '--end', '%d' % end_time,
+    '-w 800',
+    '-h 400',
+    '--title=ASU1 Read Latency',
+    '--vertical-label=Time (ms)',
+    'DEF:asu1d=pblio.rrd:asu1_rl_d:LAST',
+    'DEF:asu1c=pblio.rrd:asu1_rl_c:LAST',
+    'CDEF:asu1l=asu1d,asu1c,/,1000,/',
+    'LINE2:asu1l#FF0000:ASU1 Read Latency')
+
+rrdtool.graph('asu2_read_latency.png',
     '--start', '%d' % start_time,
     '--end', '%d' % end_time,
     '-w 800',
     '-h 400',
     '--title=ASU Read Latency',
     '--vertical-label=Time (ms)',
-    'DEF:asu1d=pblio.rrd:asu1_rl_d:LAST',
-    'DEF:asu1c=pblio.rrd:asu1_rl_c:LAST',
     'DEF:asu2d=pblio.rrd:asu2_rl_d:LAST',
     'DEF:asu2c=pblio.rrd:asu2_rl_c:LAST',
-    'CDEF:asu1l=asu1d,asu1c,/,1000,/',
     'CDEF:asu2l=asu2d,asu2c,/,1000,/',
-    'LINE2:asu1l#FF0000:ASU1 Read Latency',
     'LINE2:asu2l#00FF00:ASU2 Read Latency')
+
+# Graph ASU1 and ASU2 Read Latency
+rrdtool.graph('asu1_write_latency.png',
+    '--start', '%d' % start_time,
+    '--end', '%d' % end_time,
+    '-w 800',
+    '-h 400',
+    '--title=ASU1 Write Latency',
+    '--vertical-label=Time (ms)',
+    'DEF:asu1d=pblio.rrd:asu1_wl_d:LAST',
+    'DEF:asu1c=pblio.rrd:asu1_wl_c:LAST',
+    'CDEF:asu1l=asu1d,asu1c,/,1000,/',
+    'LINE2:asu1l#FF0000:ASU1 Write Latency')
+
+rrdtool.graph('asu2_write_latency.png',
+    '--start', '%d' % start_time,
+    '--end', '%d' % end_time,
+    '-w 800',
+    '-h 400',
+    '--title=ASU2 Write Latency',
+    '--vertical-label=Time (ms)',
+    'DEF:asu2d=pblio.rrd:asu2_wl_d:LAST',
+    'DEF:asu2c=pblio.rrd:asu2_wl_c:LAST',
+    'CDEF:asu2l=asu2d,asu2c,/,1000,/',
+    'LINE2:asu2l#00FF00:ASU2 Write Latency')
+
+rrdtool.graph('asu3_write_latency.png',
+    '--start', '%d' % start_time,
+    '--end', '%d' % end_time,
+    '-w 800',
+    '-h 400',
+    '--title=ASU3 Write Latency',
+    '--vertical-label=Time (ms)',
+    'DEF:asu3d=pblio.rrd:asu3_wl_d:LAST',
+    'DEF:asu3c=pblio.rrd:asu3_wl_c:LAST',
+    'CDEF:asu3l=asu3d,asu3c,/,1000,/',
+    'LINE2:asu3l#0000FF:ASU3 Write Latency')
 
 # Graph Read Hit Rate
 rrdtool.graph('readhit.png',

--- a/apps/pblio/spc/asu_test.go
+++ b/apps/pblio/spc/asu_test.go
@@ -25,13 +25,17 @@ import (
 
 func TestAsuNew(t *testing.T) {
 	usedirectio := false
-	asu := NewAsu(usedirectio)
+	mock_reads := false
+	mock_writes := true
+	asu := NewAsu(usedirectio, mock_reads, mock_writes)
 	tests.Assert(t, asu.usedirectio == usedirectio)
+	tests.Assert(t, asu.mock_reads == mock_reads)
+	tests.Assert(t, asu.mock_writes == mock_writes)
 	tests.Assert(t, len(asu.fps) == 0)
 	tests.Assert(t, asu.len == 0)
 
 	usedirectio = true
-	asu = NewAsu(usedirectio)
+	asu = NewAsu(usedirectio, false, false)
 	tests.Assert(t, asu.usedirectio == usedirectio)
 	tests.Assert(t, len(asu.fps) == 0)
 	tests.Assert(t, asu.len == 0)
@@ -40,7 +44,7 @@ func TestAsuNew(t *testing.T) {
 func TestAsuSize(t *testing.T) {
 
 	usedirectio := false
-	asu := NewAsu(usedirectio)
+	asu := NewAsu(usedirectio, false, false)
 
 	// set fake length
 	asu.len = 1234 * GB / (4 * KB)
@@ -49,7 +53,7 @@ func TestAsuSize(t *testing.T) {
 
 func TestAsuOpenFile(t *testing.T) {
 	usedirectio := true
-	asu := NewAsu(usedirectio)
+	asu := NewAsu(usedirectio, false, false)
 	mockfile := tests.NewMockFile()
 	mockerror := errors.New("Test Error")
 
@@ -75,7 +79,7 @@ func TestAsuOpenFile(t *testing.T) {
 
 	// Now try without directio set
 	usedirectio = false
-	asu = NewAsu(usedirectio)
+	asu = NewAsu(usedirectio, false, false)
 
 	// Check results
 	err = asu.Open("filename")
@@ -85,7 +89,7 @@ func TestAsuOpenFile(t *testing.T) {
 
 func TestAsuOpenSeek(t *testing.T) {
 	usedirectio := true
-	asu := NewAsu(usedirectio)
+	asu := NewAsu(usedirectio, false, false)
 	mockfile := tests.NewMockFile()
 
 	seeklen := int64(0)
@@ -145,7 +149,7 @@ func TestAsuOpenSeek(t *testing.T) {
 func TestAsuIoAt(t *testing.T) {
 
 	usedirectio := true
-	asu := NewAsu(usedirectio)
+	asu := NewAsu(usedirectio, false, false)
 
 	// Setup Head - 10 4k blocks
 	head := tests.NewMockFile()

--- a/apps/pblio/spc/spc.go
+++ b/apps/pblio/spc/spc.go
@@ -38,7 +38,7 @@ type SpcInfo struct {
 }
 
 func NewSpcInfo(c *cache.CacheMap,
-	usedirectio bool,
+	usedirectio, mock_reads, mock_writes bool,
 	blocksize int) *SpcInfo {
 
 	s := &SpcInfo{
@@ -47,9 +47,9 @@ func NewSpcInfo(c *cache.CacheMap,
 		blocksize: blocksize,
 	}
 
-	s.asus[ASU1] = NewAsu(usedirectio)
-	s.asus[ASU2] = NewAsu(usedirectio)
-	s.asus[ASU3] = NewAsu(usedirectio)
+	s.asus[ASU1] = NewAsu(usedirectio, mock_reads, mock_writes)
+	s.asus[ASU2] = NewAsu(usedirectio, mock_reads, mock_writes)
+	s.asus[ASU3] = NewAsu(usedirectio, mock_reads, mock_writes)
 
 	return s
 }

--- a/apps/pblio/spc/spc_test.go
+++ b/apps/pblio/spc/spc_test.go
@@ -30,9 +30,11 @@ func TestNewSpcInfo(t *testing.T) {
 	var cache *cache.CacheMap
 
 	usedirectio := false
+	mock_reads := false
+	mock_writes := true
 	blocksize := 4 * KB
 
-	s := NewSpcInfo(cache, usedirectio, blocksize)
+	s := NewSpcInfo(cache, usedirectio, mock_reads, mock_writes, blocksize)
 	tests.Assert(t, s.pblcache == cache)
 	tests.Assert(t, s.blocksize == blocksize)
 	tests.Assert(t, len(s.asus) == 3)
@@ -42,6 +44,14 @@ func TestNewSpcInfo(t *testing.T) {
 	tests.Assert(t, usedirectio == s.asus[ASU1].usedirectio)
 	tests.Assert(t, usedirectio == s.asus[ASU2].usedirectio)
 	tests.Assert(t, usedirectio == s.asus[ASU3].usedirectio)
+
+	tests.Assert(t, mock_reads == s.asus[ASU1].mock_reads)
+	tests.Assert(t, mock_reads == s.asus[ASU2].mock_reads)
+	tests.Assert(t, mock_reads == s.asus[ASU3].mock_reads)
+
+	tests.Assert(t, mock_writes == s.asus[ASU1].mock_writes)
+	tests.Assert(t, mock_writes == s.asus[ASU2].mock_writes)
+	tests.Assert(t, mock_writes == s.asus[ASU3].mock_writes)
 }
 
 func TestSpcOpen(t *testing.T) {
@@ -50,7 +60,7 @@ func TestSpcOpen(t *testing.T) {
 	var cache *cache.CacheMap
 	usedirectio := false
 	blocksize := 4 * KB
-	s := NewSpcInfo(cache, usedirectio, blocksize)
+	s := NewSpcInfo(cache, usedirectio, false, false, blocksize)
 
 	// Get a test file
 	tmpfile := tests.Tempfile()
@@ -75,7 +85,7 @@ func TestSpcAdjustAsuSizes(t *testing.T) {
 	var cache *cache.CacheMap
 	usedirectio := false
 	blocksize := 4 * KB
-	s := NewSpcInfo(cache, usedirectio, blocksize)
+	s := NewSpcInfo(cache, usedirectio, false, false, blocksize)
 
 	// Setup some fake data
 	s.asus[ASU1].len = 100
@@ -122,7 +132,7 @@ func TestSpcSize(t *testing.T) {
 	var cache *cache.CacheMap
 	usedirectio := false
 	blocksize := 4 * KB
-	s := NewSpcInfo(cache, usedirectio, blocksize)
+	s := NewSpcInfo(cache, usedirectio, false, false, blocksize)
 
 	// Set fake len
 	s.asus[ASU1].len = 40 * GB / (4 * KB)
@@ -139,7 +149,7 @@ func TestSpc1Init(t *testing.T) {
 	var cache *cache.CacheMap
 	usedirectio := false
 	blocksize := 4 * KB
-	s := NewSpcInfo(cache, usedirectio, blocksize)
+	s := NewSpcInfo(cache, usedirectio, false, false, blocksize)
 
 	// Set fake len
 	s.asus[ASU1].len = 5500
@@ -182,7 +192,7 @@ func TestSpcContext(t *testing.T) {
 	var cache *cache.CacheMap
 	usedirectio := false
 	blocksize := 4 * KB
-	s := NewSpcInfo(cache, usedirectio, blocksize)
+	s := NewSpcInfo(cache, usedirectio, false, false, blocksize)
 
 	// Setup Mockfile
 	mockfile := tests.NewMockFile()
@@ -267,7 +277,7 @@ func TestSpcContextQuit(t *testing.T) {
 	var cache *cache.CacheMap
 	usedirectio := false
 	blocksize := 4 * KB
-	s := NewSpcInfo(cache, usedirectio, blocksize)
+	s := NewSpcInfo(cache, usedirectio, false, false, blocksize)
 
 	// Setup Mockfile
 	mockfile := tests.NewMockFile()

--- a/cache/log.go
+++ b/cache/log.go
@@ -41,7 +41,7 @@ const (
 	MB                   = 1024 * KB
 	GB                   = 1024 * MB
 	TB                   = 1024 * GB
-	NumberSegmentBuffers = 512
+	NumberSegmentBuffers = 32
 )
 
 // Allows these functions to be mocked by tests

--- a/cache/log.go
+++ b/cache/log.go
@@ -41,7 +41,7 @@ const (
 	MB                   = 1024 * KB
 	GB                   = 1024 * MB
 	TB                   = 1024 * GB
-	NumberSegmentBuffers = 32
+	NumberSegmentBuffers = 512
 )
 
 // Allows these functions to be mocked by tests
@@ -149,9 +149,9 @@ func NewLog(logfile string,
 			log.blocks_per_segment, log.numsegments, log.size))
 
 	// Incoming message channel
-	log.Msgchan = make(chan *message.Message, 32)
+	log.Msgchan = make(chan *message.Message, 512)
 	log.quitchan = make(chan struct{})
-	log.logreaders = make(chan *message.Message, 32)
+	log.logreaders = make(chan *message.Message, 512)
 
 	// Segment channel state machine:
 	// 		-> Client writes available segment

--- a/cache/log_stats.go
+++ b/cache/log_stats.go
@@ -112,7 +112,15 @@ type logstats struct {
 func (s *logstats) Stats() *LogStats {
 	scopy := &logstats{}
 	s.lock.Lock()
-	*scopy = *s
+	scopy.ramhits = s.ramhits
+	scopy.storagehits = s.storagehits
+	scopy.wraps = s.wraps
+	scopy.seg_skipped = s.seg_skipped
+	scopy.bufferhits = s.bufferhits
+	scopy.totalhits = s.totalhits
+	scopy.readtime = s.readtime
+	scopy.segmentreadtime = s.segmentreadtime
+	scopy.writetime = s.writetime
 	s.lock.Unlock()
 
 	return &LogStats{

--- a/cache/stats.go
+++ b/cache/stats.go
@@ -170,7 +170,12 @@ func (c *cachestats) copy() *cachestats {
 	defer c.lock.Unlock()
 
 	statscopy := &cachestats{}
-	*statscopy = *c
+	statscopy.readhits = c.readhits
+	statscopy.invalidatehits = c.invalidatehits
+	statscopy.reads = c.reads
+	statscopy.insertions = c.insertions
+	statscopy.evictions = c.evictions
+	statscopy.invalidations = c.invalidations
 
 	return statscopy
 }


### PR DESCRIPTION
Fixed the following issues:

1. Incorrect cache size displayed
2. Out of slice index crash used to occur when doing
sparse file I/O

Improvements:

1. Added mock flags to pblio
2. Added versioning
3. pblioplot now also creates write latency images
4. Increased log channels and readers

Signed-off-by: Luis Pabón <lpabon@redhat.com>